### PR TITLE
Move request lock to VNS3 Client

### DIFF
--- a/cohesivenet/api_network_edge_plugins.go
+++ b/cohesivenet/api_network_edge_plugins.go
@@ -4019,16 +4019,13 @@ func (a *NetworkEdgePluginsApiService) InstallPluginRequest(ctx context.Context)
 // Execute executes the request
 //  @return PluginDetailResponse
 func (a *NetworkEdgePluginsApiService) InstallPlugin(r ApiInstallPluginRequest) (*PluginDetailResponse, *http.Response, error) {
+	
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}
 		formFiles            []formFile
 		localVarReturnValue  *PluginDetailResponse
 	)
-	
-	// synchronize creating a plugin image
-	a.ReqLock.Lock()
-	defer a.ReqLock.Unlock()
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "NetworkEdgePluginsApiService.InstallPlugin")
 	if err != nil {

--- a/cohesivenet/api_network_edge_plugins.go
+++ b/cohesivenet/api_network_edge_plugins.go
@@ -4019,7 +4019,6 @@ func (a *NetworkEdgePluginsApiService) InstallPluginRequest(ctx context.Context)
 // Execute executes the request
 //  @return PluginDetailResponse
 func (a *NetworkEdgePluginsApiService) InstallPlugin(r ApiInstallPluginRequest) (*PluginDetailResponse, *http.Response, error) {
-	
 	var (
 		localVarHTTPMethod   = http.MethodPost
 		localVarPostBody     interface{}

--- a/cohesivenet/vns3_client.go
+++ b/cohesivenet/vns3_client.go
@@ -49,6 +49,8 @@ type VNS3Client struct {
 	cfg    *Configuration
 	common service // Reuse a single struct instead of allocating one for each service on the heap.
 	Log CanLog
+	// used to synchronize client requests i.e. create plugin image
+	ReqLock	*sync.Mutex
 
 	// API Services
 
@@ -81,8 +83,6 @@ type VNS3Client struct {
 
 type service struct {
 	client *VNS3Client
-	// used to synchronize client requests i.e. create plugin image
-	ReqLock	   sync.Mutex
 }
 
 type ClientParams struct {
@@ -113,7 +113,8 @@ func NewVNS3Client(cfg *Configuration, params ClientParams) *VNS3Client {
 	c.cfg = cfg
 	c.common.client = c
 	c.Log = NewLogger(getLogLevel(os.Getenv("COHESIVE_LOG_LEVEL")))
-
+	c.ReqLock = new(sync.Mutex)
+	
 	// API Services
 	// For golang newbies (like me): this is casting c.common pointer (which is type service) as 
 	// a AccessApiService pointer. as VNS3Client.AccessApi is defined as type AccessApiService pointer


### PR DESCRIPTION
- move lock to client so users can block client requests if needed