### PR TITLE
check for unauthorized responses during onboot

### DIFF
--- a/cohesivenet/utils.go
+++ b/cohesivenet/utils.go
@@ -364,7 +364,9 @@ func CheckHttpErrorUnavailable(err error) (bool, string) {
         errMessage := err.Error()
         if strings.Contains(errMessage, "connection refused") {
             return true, "connrefused"
-        }
+        } else if (strings.Contains(errMessage, "Unauthorized")) {
+			return true, "unauthorized"
+		}
         return false, errMessage
     }
 


### PR DESCRIPTION
- with controller 6.x, unauthorized responses will be returned until onboot process is complete